### PR TITLE
fix/google-env-supabase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  SUPABASE_AUTH_GOOGLE_CLIENT_ID: " "
+  SUPABASE_AUTH_GOOGLE_SECRET: " "
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,9 +23,6 @@ jobs:
         run: supabase db start
 
       - name: Verify generated types are checked in
-        env:
-          SUPABASE_AUTH_GOOGLE_CLIENT_ID:
-          SUPABASE_AUTH_GOOGLE_SECRET:
         run: |
           supabase gen types typescript --local > types.gen.ts
           if ! git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then


### PR DESCRIPTION
The variables needed to use Google auth locally with supabase are required on the supabase ci workflow on GitHub actions.

This PR assigns a dummy value (whitespace character) as value for these variables.