### PR TITLE
chore/turbopack-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "build": "next build",


### PR DESCRIPTION
The PR updates the development script to use `next dev --turbo` for enabling Turbopack. This improves development performance by leveraging Turbopack's features (incremental builds, lazy bundling, etc).