### PR TITLE
chore/update-deployment-workflows

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches-ignore:
       - master
+      - staging
 jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-staging.yaml
+++ b/.github/workflows/vercel-staging.yaml
@@ -1,4 +1,4 @@
-name: Vercel Preview Deployment
+name: Vercel Staging Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
This PR updates the name of the workflow that deploys the Staging build to Vercel and adds the `staging` branch to the `branches-ignore` filter on the Preview workflow file.