### PR TITLE
chore(scripts): add scholarship scraper

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/node": "22.10.2",
     "@types/react": "^19.0.2",
     "@types/react-dom": "19.0.2",
+    "cheerio": "1.2.0",
     "dotenv": "17.2.2",
     "eslint": "9.17.0",
     "eslint-config-next": "15.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 3.10.0(react-hook-form@7.54.2(react@19.0.0))
       "@langchain/community":
         specifier: 0.3.53
-        version: 0.3.53(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.54.2)(deepmerge@4.3.1)(dotenv@17.2.2)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(zod@4.1.3))(@ibm-cloud/watsonx-ai@1.6.10)(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(@supabase/supabase-js@2.75.1)(axios@1.13.3)(handlebars@4.7.8)(ibm-cloud-sdk-core@5.4.2)(ignore@5.3.2)(jsonwebtoken@9.0.3)(lodash@4.17.21)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(playwright@1.54.2)(weaviate-client@3.8.0)(ws@8.19.0)
+        version: 0.3.53(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.54.2)(deepmerge@4.3.1)(dotenv@17.2.2)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(zod@4.1.3))(@ibm-cloud/watsonx-ai@1.6.10)(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(@supabase/supabase-js@2.75.1)(axios@1.13.3)(cheerio@1.2.0)(handlebars@4.7.8)(ibm-cloud-sdk-core@5.4.2)(ignore@5.3.2)(jsonwebtoken@9.0.3)(lodash@4.17.21)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(playwright@1.54.2)(weaviate-client@3.8.0)(ws@8.19.0)
       "@langchain/core":
         specifier: 0.3.72
         version: 0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))
@@ -90,7 +90,7 @@ importers:
         version: 1.3.1(next@15.1.11(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       langchain:
         specifier: 0.3.30
-        version: 0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0)
+        version: 0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(cheerio@1.2.0)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0)
       lucide-react:
         specifier: ^0.436.0
         version: 0.436.0(react@19.0.0)
@@ -140,6 +140,9 @@ importers:
       "@types/react-dom":
         specifier: 19.0.2
         version: 19.0.2(@types/react@19.0.2)
+      cheerio:
+        specifier: 1.2.0
+        version: 1.2.0
       dotenv:
         specifier: 17.2.2
         version: 17.2.2
@@ -3070,6 +3073,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  boolbase@1.0.0:
+    resolution:
+      {
+        integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
+      }
+
   bottleneck@2.19.5:
     resolution:
       {
@@ -3204,6 +3213,19 @@ packages:
         integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==,
       }
     engines: { node: ">=10" }
+
+  cheerio-select@2.1.0:
+    resolution:
+      {
+        integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==,
+      }
+
+  cheerio@1.2.0:
+    resolution:
+      {
+        integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==,
+      }
+    engines: { node: ">=20.18.1" }
 
   chokidar@3.6.0:
     resolution:
@@ -3437,6 +3459,19 @@ packages:
       }
     engines: { node: ">=12" }
 
+  css-select@5.2.2:
+    resolution:
+      {
+        integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==,
+      }
+
+  css-what@6.2.2:
+    resolution:
+      {
+        integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
+      }
+    engines: { node: ">= 6" }
+
   cssesc@3.0.0:
     resolution:
       {
@@ -3613,6 +3648,31 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  dom-serializer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
+      }
+
+  domelementtype@2.3.0:
+    resolution:
+      {
+        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
+      }
+
+  domhandler@5.0.3:
+    resolution:
+      {
+        integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
+      }
+    engines: { node: ">= 4" }
+
+  domutils@3.2.2:
+    resolution:
+      {
+        integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
+      }
+
   dot-prop@5.3.0:
     resolution:
       {
@@ -3683,12 +3743,39 @@ packages:
         integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==,
       }
 
+  encoding-sniffer@0.2.1:
+    resolution:
+      {
+        integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==,
+      }
+
   enhanced-resolve@5.18.0:
     resolution:
       {
         integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==,
       }
     engines: { node: ">=10.13.0" }
+
+  entities@4.5.0:
+    resolution:
+      {
+        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
+      }
+    engines: { node: ">=0.12" }
+
+  entities@6.0.1:
+    resolution:
+      {
+        integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
+      }
+    engines: { node: ">=0.12" }
+
+  entities@7.0.1:
+    resolution:
+      {
+        integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==,
+      }
+    engines: { node: ">=0.12" }
 
   env-ci@11.2.0:
     resolution:
@@ -4564,6 +4651,12 @@ packages:
       }
     engines: { node: ^18.17.0 || >=20.5.0 }
 
+  htmlparser2@10.1.0:
+    resolution:
+      {
+        integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==,
+      }
+
   http-proxy-agent@7.0.2:
     resolution:
       {
@@ -4611,6 +4704,13 @@ packages:
         integrity: sha512-5VFkKYU/vSIWFJTVt392XEdPmiEwUJqhxjn1MRO3lfELyU2FB+yYi8brbmXUgq+D1acHR1fpS7tIJ6IlnrR9Cg==,
       }
     engines: { node: ">=18" }
+
+  iconv-lite@0.6.3:
+    resolution:
+      {
+        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   ieee754@1.2.1:
     resolution:
@@ -5755,6 +5855,12 @@ packages:
       - which
       - write-file-atomic
 
+  nth-check@2.1.1:
+    resolution:
+      {
+        integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
+      }
+
   object-assign@4.1.1:
     resolution:
       {
@@ -6040,6 +6146,18 @@ packages:
         integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==,
       }
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution:
+      {
+        integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==,
+      }
+
+  parse5-parser-stream@7.1.2:
+    resolution:
+      {
+        integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==,
+      }
+
   parse5@5.1.1:
     resolution:
       {
@@ -6050,6 +6168,12 @@ packages:
     resolution:
       {
         integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==,
+      }
+
+  parse5@7.3.0:
+    resolution:
+      {
+        integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
       }
 
   path-exists@3.0.0:
@@ -6632,6 +6756,12 @@ packages:
         integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
       }
     engines: { node: ">= 0.4" }
+
+  safer-buffer@2.1.2:
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   scheduler@0.25.0:
     resolution:
@@ -7307,6 +7437,13 @@ packages:
         integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==,
       }
 
+  undici@7.22.0:
+    resolution:
+      {
+        integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==,
+      }
+    engines: { node: ">=20.18.1" }
+
   unicode-emoji-modifier-base@1.0.0:
     resolution:
       {
@@ -7483,6 +7620,21 @@ packages:
       {
         integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
       }
+
+  whatwg-encoding@3.1.1:
+    resolution:
+      {
+        integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
+      }
+    engines: { node: ">=18" }
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution:
+      {
+        integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
+      }
+    engines: { node: ">=18" }
 
   whatwg-url@5.0.0:
     resolution:
@@ -8062,7 +8214,7 @@ snapshots:
 
   "@js-sdsl/ordered-map@4.4.2": {}
 
-  "@langchain/community@0.3.53(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.54.2)(deepmerge@4.3.1)(dotenv@17.2.2)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(zod@4.1.3))(@ibm-cloud/watsonx-ai@1.6.10)(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(@supabase/supabase-js@2.75.1)(axios@1.13.3)(handlebars@4.7.8)(ibm-cloud-sdk-core@5.4.2)(ignore@5.3.2)(jsonwebtoken@9.0.3)(lodash@4.17.21)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(playwright@1.54.2)(weaviate-client@3.8.0)(ws@8.19.0)":
+  "@langchain/community@0.3.53(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.54.2)(deepmerge@4.3.1)(dotenv@17.2.2)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(zod@4.1.3))(@ibm-cloud/watsonx-ai@1.6.10)(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(@supabase/supabase-js@2.75.1)(axios@1.13.3)(cheerio@1.2.0)(handlebars@4.7.8)(ibm-cloud-sdk-core@5.4.2)(ignore@5.3.2)(jsonwebtoken@9.0.3)(lodash@4.17.21)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(playwright@1.54.2)(weaviate-client@3.8.0)(ws@8.19.0)":
     dependencies:
       "@browserbasehq/stagehand": 1.14.0(@playwright/test@1.54.2)(deepmerge@4.3.1)(dotenv@17.2.2)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(zod@4.1.3)
       "@ibm-cloud/watsonx-ai": 1.6.10
@@ -8074,7 +8226,7 @@ snapshots:
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.2
       js-yaml: 4.1.0
-      langchain: 0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0)
+      langchain: 0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(cheerio@1.2.0)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0)
       langsmith: 0.3.61(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))
       openai: 5.12.2(ws@8.19.0)(zod@4.1.3)
       uuid: 10.0.0
@@ -8082,6 +8234,7 @@ snapshots:
     optionalDependencies:
       "@browserbasehq/sdk": 2.6.0
       "@supabase/supabase-js": 2.75.1
+      cheerio: 1.2.0
       ignore: 5.3.2
       jsonwebtoken: 9.0.3
       lodash: 4.17.21
@@ -9375,6 +9528,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  boolbase@1.0.0: {}
+
   bottleneck@2.19.5: {}
 
   brace-expansion@1.1.11:
@@ -9452,6 +9607,29 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.22.0
+      whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -9602,6 +9780,16 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
@@ -9681,6 +9869,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -9713,10 +9919,21 @@ snapshots:
 
   emojilib@2.4.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-ci@11.2.0:
     dependencies:
@@ -10465,6 +10682,13 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -10508,6 +10732,10 @@ snapshots:
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -10794,7 +11022,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langchain@0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0):
+  langchain@0.3.30(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(@opentelemetry/api@1.9.0)(axios@1.13.3)(cheerio@1.2.0)(handlebars@4.7.8)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))(ws@8.19.0):
     dependencies:
       "@langchain/core": 0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3))
       "@langchain/openai": 0.6.9(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@4.1.3)))(ws@8.19.0)
@@ -10810,6 +11038,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       axios: 1.13.3(debug@4.4.3)
+      cheerio: 1.2.0
       handlebars: 4.7.8
     transitivePeerDependencies:
       - "@opentelemetry/api"
@@ -11065,6 +11294,10 @@ snapshots:
 
   npm@10.9.4: {}
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -11229,9 +11462,22 @@ snapshots:
     dependencies:
       parse5: 6.0.1
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@5.1.1: {}
 
   parse5@6.0.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@3.0.0: {}
 
@@ -11572,6 +11818,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.25.0: {}
 
@@ -12070,6 +12318,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici@7.22.0: {}
+
   unicode-emoji-modifier-base@1.0.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -12157,6 +12407,12 @@ snapshots:
   web-worker@1.2.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:

--- a/scripts/scrape-scholarship.ts
+++ b/scripts/scrape-scholarship.ts
@@ -1,0 +1,191 @@
+import dotenv from "dotenv";
+import fs from "fs/promises";
+import path from "path";
+import * as cheerio from "cheerio";
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { z } from "zod";
+
+// Load environment variables
+dotenv.config({ path: path.join(process.cwd(), ".env.local") });
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!OPENAI_API_KEY) {
+  console.error("Missing required environment variable: OPENAI_API_KEY");
+  process.exit(1);
+}
+
+// CLI args
+const [url, universityCode] = process.argv.slice(2);
+
+if (!url || !universityCode) {
+  console.error(
+    "Usage: npx tsx scripts/scrape-scholarship.ts <url> <university-code>",
+  );
+  console.error(
+    "Example: npx tsx scripts/scrape-scholarship.ts https://uchile.cl/dbe/bab uch",
+  );
+  process.exit(1);
+}
+
+const scholarshipContentSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      "The scholarship content exactly as it appears on the page. Remove any remaining navigation, breadcrumbs, sidebars, social media buttons, footers, or promotional boilerplate. Preserve every section that is actually present — do not add, rename, or reorganize sections, and do not summarize.",
+    ),
+  scholarship_name: z.string().describe("The official scholarship name"),
+});
+
+const promptTemplate = ChatPromptTemplate.fromMessages([
+  [
+    "system",
+    `You are extracting scholarship content from a Chilean university webpage.
+
+Your only job is to clean and preserve — not transform.
+
+Rules:
+- Keep every section that exists on the page (dates, requirements, processes, renewal conditions, contact info, etc.)
+- Preserve the exact section names and order as they appear
+- Remove ONLY: navigation menus, breadcrumbs, sidebars, social media buttons, footers, related links panels, and promotional boilerplate unrelated to this scholarship
+- Do NOT add sections, headings, or structure that is not in the original
+- Do NOT summarize, rewrite, or infer information
+- If a page has just one paragraph with no sections, the output should be just that paragraph
+- Output plain text`,
+  ],
+  [
+    "human",
+    `URL: {url}
+
+Page content:
+{text}`,
+  ],
+]);
+
+const llm = new ChatOpenAI({
+  apiKey: OPENAI_API_KEY,
+  model: "gpt-4o-mini",
+  temperature: 0,
+});
+
+const structuredLlm = llm.withStructuredOutput(scholarshipContentSchema, {
+  name: "scholarship_content_extractor",
+});
+
+function extractStructuredText($: cheerio.CheerioAPI): string {
+  // Remove boilerplate elements
+  $(
+    "script, style, nav, header, footer, aside, [role='navigation'], [role='banner'], [role='contentinfo'], .breadcrumb, .breadcrumbs, .sidebar",
+  ).remove();
+
+  const lines: string[] = [];
+
+  function walk(el: ReturnType<typeof $>[0]) {
+    if (el.type === "text") {
+      const text = "data" in el ? String(el.data).trim() : "";
+      if (text) lines.push(text);
+      return;
+    }
+
+    if (el.type !== "tag") return;
+
+    const tag = "tagName" in el ? String(el.tagName).toLowerCase() : "";
+
+    if (/^h[1-6]$/.test(tag)) {
+      const text = $(el).text().trim();
+      if (text) lines.push(`\n\n${text}\n`);
+      return;
+    }
+
+    if (tag === "p") {
+      const text = $(el).text().trim();
+      if (text) lines.push(`\n\n${text}`);
+      return;
+    }
+
+    if (tag === "li") {
+      const text = $(el).text().trim();
+      if (text) lines.push(`\n- ${text}`);
+      return;
+    }
+
+    if (tag === "br") {
+      lines.push("\n");
+      return;
+    }
+
+    $(el)
+      .contents()
+      .each((_, child) => walk(child));
+  }
+
+  $("body")
+    .contents()
+    .each((_, el) => walk(el));
+
+  return lines
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function scrapeScholarship(url: string, universityCode: string) {
+  console.log(`Fetching: ${url}`);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  const html = await response.text();
+
+  console.log("Parsing HTML...");
+  const $ = cheerio.load(html);
+  const pageText = extractStructuredText($);
+
+  console.log("Extracting scholarship content with AI...");
+  const prompt = await promptTemplate.invoke({ url, text: pageText });
+  const result = await structuredLlm.invoke(prompt);
+
+  console.log(`Title: ${result.scholarship_name}`);
+
+  const filename = result.scholarship_name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  const finalContent = `${url}\n\n${result.content}`;
+
+  const outputDir = path.join(process.cwd(), "scholarships", universityCode);
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const filePath = path.join(outputDir, `${filename}.txt`);
+
+  let exists = false;
+  try {
+    await fs.access(filePath);
+    exists = true;
+  } catch {
+    // file doesn't exist
+  }
+  if (exists) {
+    console.warn(`Warning: overwriting existing file: ${filePath}`);
+  }
+
+  await fs.writeFile(filePath, finalContent, "utf-8");
+
+  console.log(`Saved: ${filePath}`);
+  return filePath;
+}
+
+(async () => {
+  try {
+    await scrapeScholarship(url, universityCode);
+    console.log("\nDone.");
+  } catch (error) {
+    console.error("Script failed:", error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `scripts/scrape-scholarship.ts`, a CLI script that fetches a university scholarship page, extracts the relevant content using an LLM, and saves it as a `.txt` file to be used as source of truth by the downstream `extract-scholarship-info.ts` and `populate-scholarship.ts` scripts.

**Usage:**
```
npx tsx scripts/scrape-scholarship.ts <url> <university-code>
```

Key design decisions:
- Accepts URL and university code as CLI args (no hardcoded values)
- Two-pass HTML extraction with Cheerio: removes boilerplate elements first, then walks the DOM preserving structure (headings, paragraphs, lists) before sending to the LLM
- Output format: `{url}\n\n{content}` — title is not prepended since it is always present as part of the page content
- Warns and overwrites if the output file already exists
- Auto-creates the `scholarships/{university-code}/` directory if it doesn't exist
- Uses `gpt-4o-mini` with structured output (Zod schema) for deterministic extraction

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Run the script against any Chilean university scholarship URL:

```bash
npx tsx scripts/scrape-scholarship.ts https://uchile.cl/dbe/buch uch
```

Verify the generated `.txt` file in `scholarships/uch/` contains the URL on the first line followed by the scholarship content with sections preserved as-is.

### UI accessibility checklist

_N/A — script only, no UI changes._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this is a one-off data collection script that calls an external LLM and web pages; unit testing would require mocking both and adds little value at this stage
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?